### PR TITLE
Support v1_0 for ogc:api tiles with reading landing page

### DIFF
--- a/ngr_spider/models.py
+++ b/ngr_spider/models.py
@@ -77,13 +77,24 @@ class WmsLayer(Layer):
     minscale: str = ""
     maxscale: str = ""
 
+@dataclasses.dataclass
+class OatTileSet():
+    tileset_title: str
+    tileset_crs: str
+    tileset_data_type: str
+    tileset_min_scale: str = ""
+    tileset_max_scale: str = ""
+
 
 @dataclasses.dataclass
-class OatLayer(Layer):
+class OatTiles():
+    title: str
+    abstract: str
+    tilesets: list[OatTileSet]
+
+@dataclasses.dataclass
+class OatStyleLayer(Layer):
     styles: list[VectorTileStyle]
-    crs: str
-    minscale: str = ""
-    maxscale: str = ""
 
 
 @dataclasses.dataclass
@@ -310,7 +321,7 @@ class WmsService(Service):
 
 @dataclasses.dataclass(kw_only=True)
 class OatService(Service):
-    layers: list[OatLayer]
+    layers: list[OatStyleLayer]
     protocol: str = OAT_PROTOCOL
 
 

--- a/ngr_spider/models.py
+++ b/ngr_spider/models.py
@@ -58,6 +58,7 @@ class Style:
 
 @dataclasses.dataclass
 class VectorTileStyle:
+    id: str
     name: str
     url: str
 
@@ -93,7 +94,7 @@ class OatTiles():
     tilesets: list[OatTileSet]
 
 @dataclasses.dataclass
-class OatStyleLayer(Layer):
+class OatLayer(Layer):
     styles: list[VectorTileStyle]
 
 
@@ -321,7 +322,7 @@ class WmsService(Service):
 
 @dataclasses.dataclass(kw_only=True)
 class OatService(Service):
-    layers: list[OatStyleLayer]
+    layers: list[OatLayer]
     protocol: str = OAT_PROTOCOL
 
 

--- a/ngr_spider/ogc_api_tiles.py
+++ b/ngr_spider/ogc_api_tiles.py
@@ -89,7 +89,6 @@ class OGCApiTiles:
     def get_layers(self):
         tiles_title: str
         tiles_abstract: str
-#We doen in de viewer nog niets met de verschillende tilesets
 #         tileset_titles: str = ""
 #         tileset_crs: str = ""
 #         tileset_min_scale: str = ""
@@ -110,7 +109,6 @@ class OGCApiTiles:
 #                         tileset_title = tile["title"]
 #                         tileset_crs = tile["crs"]
 #                         tileset_data_type: tile["dataType"]
-        styles = self.get_styles()
 
         layer = OatLayer(
             tiles_title,

--- a/ngr_spider/ogc_api_tiles.py
+++ b/ngr_spider/ogc_api_tiles.py
@@ -141,11 +141,11 @@ class OGCApiTiles:
             for link in links:
                 if link["rel"] == "service-desc":
                     self.service_desc = ServiceDesc(link["href"])
-                elif link["rel"] == "data":
+                elif link["rel"] == "data" or link["rel"].endswith('styles'):
                     self.data = Data(link["href"])
-                elif link["rel"] == "tiles":
+                elif link["rel"] == "tiles" or link["rel"].endswith('tilesets-vector'):
                     self.tiles = Tiles(link["href"])
-                elif link["rel"] == "tileMatrixSets":
+                elif link["rel"] == "tileMatrixSets" or link["rel"].endswith('tiling-schemes'):
                     self.tile_matrix_sets = TileMatrixSets(link["href"])
             title = response_body_data["title"]
             self.title = title if title else ""

--- a/ngr_spider/util.py
+++ b/ngr_spider/util.py
@@ -318,12 +318,16 @@ def get_oat_service(
             # this is a secure layer not for the general public: ignore
             return service_record
         oat = OGCApiTiles(url)
+        LOGGER.info('HALLO', oat.title)
         title = oat.title or oat.service_desc.get_info().title or ""
         description = oat.description or oat.service_desc.get_info().description or ""
 
         layers = oat.get_layers()
+
         for layer in layers:
+            LOGGER.info('BLUB',layer.name)
             layer.dataset_metadata_id = service_record.dataset_metadata_id
+
 
         return OatService(
             # http://docs.ogc.org/DRAFTS/19-072.html#rc_landing-page-section

--- a/ngr_spider/util.py
+++ b/ngr_spider/util.py
@@ -73,7 +73,6 @@ def get_output(
     if jq_filter:
         transformed_config_text = jq.compile(jq_filter).input(config).text()
         config = json.loads(transformed_config_text)
-
     if yaml_output:
         content = yaml.dump(config, default_flow_style=False)
     else:
@@ -318,23 +317,22 @@ def get_oat_service(
             # this is a secure layer not for the general public: ignore
             return service_record
         oat = OGCApiTiles(url)
-        LOGGER.info('HALLO', oat.title)
         title = oat.title or oat.service_desc.get_info().title or ""
         description = oat.description or oat.service_desc.get_info().description or ""
 
         layers = oat.get_layers()
 
         for layer in layers:
-            LOGGER.info('BLUB',layer.name)
             layer.dataset_metadata_id = service_record.dataset_metadata_id
 
+        service_url = oat.service_desc.get_tile_request_url()
 
         return OatService(
             # http://docs.ogc.org/DRAFTS/19-072.html#rc_landing-page-section
             title=title,
             abstract=description,
             metadata_id=md_id,
-            url=oat.service_desc.get_tile_request_url(),
+            url=service_url,
             layers=layers,
             keywords=oat.service_desc.get_tags(),
             dataset_metadata_id=service_record.dataset_metadata_id,


### PR DESCRIPTION
# Omschrijving

Een kleine fix om voor de v1_0 ogc:api tiles endpoints de landing page correct uit te lezen conform de standaard. 

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Minor change (typo, formatting, version bump)
- Bugfix

# Checklist:

- [ ] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)