### PR TITLE
Append tiles with tilesets and crs/id for OatLayer

### DIFF
--- a/ngr_spider/models.py
+++ b/ngr_spider/models.py
@@ -80,12 +80,8 @@ class WmsLayer(Layer):
 
 @dataclasses.dataclass
 class OatTileSet():
-    tileset_title: str
+    tileset_id: str
     tileset_crs: str
-    tileset_data_type: str
-    tileset_min_scale: str = ""
-    tileset_max_scale: str = ""
-
 
 @dataclasses.dataclass
 class OatTiles():
@@ -96,6 +92,7 @@ class OatTiles():
 @dataclasses.dataclass
 class OatLayer(Layer):
     styles: list[VectorTileStyle]
+    tiles: list[OatTiles]
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

Nu wordt ook de crs meegegeven in OAT layer, het verschil van de output met de volgende command:
`ngr-spider layers --snake-case --pretty -p 'OGC:API tiles' -m flat ogcapitiles9.json `

Voor change:

```
{
            "name": "Basisregistratie Adressen en Gebouwen - Tiles",
            "title": "Basisregistratie Adressen en Gebouwen - Tiles",
            "abstract": "Deze hele dataset is beschikbaar via OGC API Tiles. Tiles kunnen zowel vector als raster data bevatten en in meerdere projecties beschikbaar worden gesteld. In het geval van vector tiles biedt PDOK ook styles aan.",
            "dataset_metadata_id": "aa3b5e6e-7baa-40c0-8972-3353e927ec2f",
            "styles": [
                {
                    "id": "bag_standaardvisualisatie",
                    "name": "BAG Standaardvisualisatie",
                    "url": "https://api.pdok.nl/lv/bag/ogc/v1_0/styles/bag_standaardvisualisatie?f=mapbox"
                },
                {
                    "id": "bag_standaardvisualisatie_compleet",
                    "name": "BAG Standaardvisualisatie compleet",
                    "url": "https://api.pdok.nl/lv/bag/ogc/v1_0/styles/bag_standaardvisualisatie_compleet?f=mapbox"
                }
            ],
            "service_url": "https://api.pdok.nl/lv/bag/ogc/v1_0/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}",
            "service_title": "Basisregistratie Adressen en Gebouwen",
            "service_abstract": "De gegevens bestaan uit BAG-panden inclusief panden met de status 'gesloopt' en een deelselectie van BAG-gegevens van deze panden en de zich daarin bevindende verblijfsobjecten. Ook de ligplaatsen en standplaatsen zijn hierin opgenomen met een deelselectie van BAG-gegevens. Lees meer over de BAG en bekijk de BAG vector tiles in de Vectortile Viewer.",
            "service_protocol": "OGC:API tiles",
            "service_metadata_id": "b0f20313-2892-415e-82c1-bf77a984e8d8"
        }
```

Na change:

```
{
            "name": "Basisregistratie Adressen en Gebouwen - Tiles",
            "title": "Basisregistratie Adressen en Gebouwen - Tiles",
            "abstract": "Deze hele dataset is beschikbaar via OGC API Tiles. Tiles kunnen zowel vector als raster data bevatten en in meerdere projecties beschikbaar worden gesteld. In het geval van vector tiles biedt PDOK ook styles aan.",
            "dataset_metadata_id": "aa3b5e6e-7baa-40c0-8972-3353e927ec2f",
            "styles": [
                {
                    "id": "bag_standaardvisualisatie",
                    "name": "BAG Standaardvisualisatie",
                    "url": "https://api.pdok.nl/lv/bag/ogc/v1_0/styles/bag_standaardvisualisatie?f=mapbox"
                },
                {
                    "id": "bag_standaardvisualisatie_compleet",
                    "name": "BAG Standaardvisualisatie compleet",
                    "url": "https://api.pdok.nl/lv/bag/ogc/v1_0/styles/bag_standaardvisualisatie_compleet?f=mapbox"
                }
            ],
            "tiles": [
                {
                    "title": "Basisregistratie Adressen en Gebouwen - Tiles",
                    "abstract": "Deze hele dataset is beschikbaar via OGC API Tiles. Tiles kunnen zowel vector als raster data bevatten en in meerdere projecties beschikbaar worden gesteld. In het geval van vector tiles biedt PDOK ook styles aan.",
                    "tilesets": [
                        {
                            "tileset_id": "NetherlandsRDNewQuad",
                            "tileset_crs": "https://www.opengis.net/def/crs/EPSG/0/28992"
                        },
                        {
                            "tileset_id": "EuropeanETRS89_LAEAQuad",
                            "tileset_crs": "https://www.opengis.net/def/crs/EPSG/0/3035"
                        },
                        {
                            "tileset_id": "WebMercatorQuad",
                            "tileset_crs": "https://www.opengis.net/def/crs/EPSG/0/3857"
                        }
                    ]
                }
            ],
            "service_url": "https://api.pdok.nl/lv/bag/ogc/v1_0/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}",
            "service_title": "Basisregistratie Adressen en Gebouwen",
            "service_abstract": "De gegevens bestaan uit BAG-panden inclusief panden met de status 'gesloopt' en een deelselectie van BAG-gegevens van deze panden en de zich daarin bevindende verblijfsobjecten. Ook de ligplaatsen en standplaatsen zijn hierin opgenomen met een deelselectie van BAG-gegevens. Lees meer over de BAG en bekijk de BAG vector tiles in de Vectortile Viewer.",
            "service_protocol": "OGC:API tiles",
            "service_metadata_id": "b0f20313-2892-415e-82c1-bf77a984e8d8"
        }
```
