### PR TITLE
Extract max-zoomlevel api tiles as int

### DIFF
--- a/ngr_spider/models.py
+++ b/ngr_spider/models.py
@@ -82,7 +82,7 @@ class WmsLayer(Layer):
 class OatTileSet():
     tileset_id: str
     tileset_crs: str
-    tileset_zoomlevel: int
+    tileset_max_zoomlevel: int
 
 @dataclasses.dataclass
 class OatTiles():

--- a/ngr_spider/models.py
+++ b/ngr_spider/models.py
@@ -82,6 +82,7 @@ class WmsLayer(Layer):
 class OatTileSet():
     tileset_id: str
     tileset_crs: str
+    tileset_zoomlevel: int
 
 @dataclasses.dataclass
 class OatTiles():

--- a/ngr_spider/ogc_api_tiles.py
+++ b/ngr_spider/ogc_api_tiles.py
@@ -160,12 +160,12 @@ class OGCApiTiles:
         tilesets_json = self.tiles.json["tilesets"]
         for tileset in tilesets_json:
             tileset_url = self.get_self_link(tileset['links'])
-            tileset_zoom = self.get_zoomlevel(tileset_url)
+            tileset_max_zoomlevel = self.get_zoomlevel(tileset_url)
             tilesets.append(
                 OatTileSet(
                     tileset_id = tileset["tileMatrixSetId"],
                     tileset_crs = tileset["crs"],
-                    tileset_zoomlevel = tileset_zoom
+                    tileset_max_zoomlevel = tileset_max_zoomlevel
                 )
             )
         return tilesets

--- a/ngr_spider/ogc_api_tiles.py
+++ b/ngr_spider/ogc_api_tiles.py
@@ -159,10 +159,29 @@ class OGCApiTiles:
         tilesets: list[OatTileSet] = []
         tilesets_json = self.tiles.json["tilesets"]
         for tileset in tilesets_json:
+            tileset_url = self.get_self_link(tileset['links'])
+            tileset_zoom = self.get_zoomlevel(tileset_url)
             tilesets.append(
                 OatTileSet(
                     tileset_id = tileset["tileMatrixSetId"],
-                    tileset_crs = tileset["crs"]
+                    tileset_crs = tileset["crs"],
+                    tileset_zoomlevel = tileset_zoom
                 )
             )
         return tilesets
+    
+    def get_self_link(self, links):
+        for link in links:
+            if link.get('rel') == 'self':
+                return link.get('href')
+        return links[0].get('href')
+    
+    def get_zoomlevel(self, tileset_url):
+        with urllib.request.urlopen(tileset_url) as url:
+            tileset_info = json.load(url)
+        tile_matrix_limits = tileset_info.get('tileMatrixSetLimits', [])
+        max_tile_matrix_zoom = max(
+                    (int(limit.get('tileMatrix')) for limit in tile_matrix_limits),
+                    default=None
+                )
+        return max_tile_matrix_zoom


### PR DESCRIPTION
# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

Extract the max-zoomlevel for vectortile (per crs/id for tileset). This value will be used specifically for the pdokservicesplugin (QGIS plugin). 