### PR TITLE
Allow for 'tags' property not being present in OGC API tiles JSON

### DIFF
--- a/ngr_spider/ogc_api_tiles.py
+++ b/ngr_spider/ogc_api_tiles.py
@@ -27,7 +27,7 @@ class ServiceDesc:
         return Info(self.json["info"])
 
     def get_tags(self):
-        return self.json["tags"]
+        return self.json.get('tags', []) or []
 
     def get_servers(self):
         return self.json["servers"]


### PR DESCRIPTION
# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

Na laatste wijziging levert opvragen van `OGC:API tiles` layers een foutmelding op:

```
2024-04-29 15:49:00,062 - ngr_spider.util - ERROR - unexpected error occured while retrieving cap doc, md-identifier 356fc922-f910-4874-b72a-dbb18c1bed3e, url: https://api.pdok.nl/lv/bgt/ogc/v1_0/
Traceback (most recent call last):
  File "ngr-services-spider/ngr_spider/util.py", line 337, in get_oat_service
    keywords=oat.service_desc.get_tags(),
  File "ngr-services-spider/ngr_spider/ogc_api_tiles.py", line 30, in get_tags
    return self.json["tags"]
KeyError: 'tags'
```
Daarom naar voorbeeld van `ogc_api_features.py` de return logica aangepast, daarmee worden de records correct opgehaald:

```
$ ngr-spider layers -p 'OGC:API tiles' pdok-services.json
2024-04-29 15:51:28,376 - ngr_spider - INFO - main_layers start.
2024-04-29 15:51:28,798 - ngr_spider.csw_client - INFO - Number of matched services before filtering: 3
2024-04-29 15:51:28,800 - ngr_spider.csw_client - INFO - found 3 OGC:API tiles service metadata records
2024-04-29 15:51:28,800 - ngr_spider.util - INFO - b0f20313-2892-415e-82c1-bf77a984e8d8 - https://api.pdok.nl/lv/bag/ogc/v1_0/
2024-04-29 15:51:28,801 - ngr_spider.util - INFO - 356fc922-f910-4874-b72a-dbb18c1bed3e - https://api.pdok.nl/lv/bgt/ogc/v1_0/
2024-04-29 15:51:28,801 - ngr_spider.util - INFO - 24a529f3-6647-46e3-a635-c993f64eddee - https://api.pdok.nl/kadaster/bestuurlijkegebieden/ogc/v1_0
2024-04-29 15:51:29,689 - ngr_spider.util - INFO - write result to local file system
2024-04-29 15:51:29,689 - ngr_spider - INFO - indexed 3 services with 3 layers/featuretypes/coverages
2024-04-29 15:51:29,689 - ngr_spider - INFO - main_layers end.
2024-04-29 15:51:29,689 - ngr_spider - INFO - output written to pdok-services.json
```

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Bugfix

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)