### PR TITLE
Replace jq with jqpy and fixed asyncio behaviour for cpython > 3.10

### DIFF
--- a/ngr_spider/util.py
+++ b/ngr_spider/util.py
@@ -13,7 +13,7 @@ from types import MethodType
 from typing import Union
 from urllib import parse
 
-import jq
+from jqpy import jq
 import requests
 import yaml
 from azure.storage.blob import BlobClient, ContentSettings
@@ -139,7 +139,12 @@ def join_lists_by_property(list_1, list_2, prop_name):
 async def get_data_asynchronous(results, fun):
     result = []
     with ThreadPoolExecutor(max_workers=10) as executor:
-        loop = asyncio.get_event_loop()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
         tasks = [
             loop.run_in_executor(
                 executor,
@@ -540,7 +545,11 @@ def sort_flat_layers(layers, rules_path):
 def get_services(
     service_records: list[CswServiceRecord],
 ) -> list[Union[Service, ServiceError]]:
-    loop = asyncio.get_event_loop()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     future = asyncio.ensure_future(get_data_asynchronous(service_records, get_service))
     loop.run_until_complete(future)
     services_list: list[Union[Service, ServiceError]] = future.result()
@@ -550,7 +559,11 @@ def get_services(
 def get_csw_datasets(
     client: CSWClient, dataset_ids: list[str]
 ) -> list[CswDatasetRecord]:
-    loop = asyncio.get_event_loop()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     future = asyncio.ensure_future(
         get_data_asynchronous(dataset_ids, client.get_dataset_metadata)
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,7 @@ readme = { file = "./README.md", content-type = "text/markdown" }
 dependencies = [
     "azure-storage-blob >= 12.14.1",
     "dataclass-wizard >= 0.22.2",
-    "jq>=1.3.0; platform_system != 'Windows'",
-    "jqpy>=1.0.0; platform_system == 'Windows'",
+    "jqpy>=1.0.0;",
     "lxml >= 4.9.1",
     "OWSLib >= 0.28.1",
     "requests >= 2.25.0",    

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ readme = { file = "./README.md", content-type = "text/markdown" }
 dependencies = [
     "azure-storage-blob >= 12.14.1",
     "dataclass-wizard >= 0.22.2",
-    "jq >= 1.3.0",
+    "jq>=1.3.0; platform_system != 'Windows'",
+    "jqpy>=1.0.0; platform_system == 'Windows'",
     "lxml >= 4.9.1",
     "OWSLib >= 0.28.1",
     "requests >= 2.25.0",    


### PR DESCRIPTION
# Description

- Replaced jq with jqpy. Jq is not available on windows, jqpy seems to be a 1:1 replacement.
- Updated async io errors: get_event_loop does not always return an eventloop if it does not exist yet. Updated behaviour for post 3.10 behaviour and compatiblity pre 3.10 event loops. See https://github.com/python/cpython/issues/94174        

## Type of change

- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR